### PR TITLE
Made plugin compatible with Shopware 5.3 and above

### DIFF
--- a/Components/Listing.php
+++ b/Components/Listing.php
@@ -162,15 +162,17 @@ class Listing
      */
     public function getCategoryBaseSort($categoryId)
     {
+        $defaultListingSorting = Shopware()->Config()->get('defaultListingSorting');
+
         /* @var CategoryAttributes $categoryAttributes */
         $categoryAttributes = $this->categoryAttributesRepo->findOneBy(['categoryId' => $categoryId]);
         if (!$categoryAttributes instanceof CategoryAttributes) {
-            return false;
+            return $defaultListingSorting;
         }
 
         $baseSortId = $categoryAttributes->getSwagBaseSort();
         if ($baseSortId === null) {
-            return false;
+            return $defaultListingSorting;
         }
 
         return $baseSortId;

--- a/Controllers/Backend/CustomSort.php
+++ b/Controllers/Backend/CustomSort.php
@@ -42,6 +42,14 @@ class Shopware_Controllers_Backend_CustomSort extends Shopware_Controllers_Backe
      */
     private $events;
 
+    public function preDispatch()
+    {
+        parent::preDispatch();
+
+        $categoryId = (int) $this->Request()->getParam('categoryId');
+        $this->generateCategoryAttribute($categoryId);
+    }
+
     /**
      * Get product list and images for current category
      */
@@ -260,6 +268,34 @@ class Shopware_Controllers_Backend_CustomSort extends Shopware_Controllers_Backe
         }
 
         $this->View()->assign(['success' => true]);
+    }
+
+    /**
+     * Generates an empty attribute for a category if none exists
+     *
+     * @param int $categoryId
+     */
+    private function generateCategoryAttribute($categoryId)
+    {
+        try {
+            /** @var Category $category */
+            $category = $this->getModelManager()->find(Category::class, $categoryId);
+        } catch (\Exception $exception) {
+            return;
+        }
+
+        if ($category === null || $category->getAttribute() !== null) {
+            return;
+        }
+
+        try {
+            $attribute = new \Shopware\Models\Attribute\Category();
+            $this->getModelManager()->persist($attribute);
+            $category->setAttribute($attribute);
+            $this->getModelManager()->flush($category);
+        } catch (\Exception $exception) {
+            return;
+        }
     }
 
     /**

--- a/Subscriber/Frontend.php
+++ b/Subscriber/Frontend.php
@@ -9,6 +9,7 @@
 namespace Shopware\SwagCustomSort\Subscriber;
 
 use Enlight\Event\SubscriberInterface;
+use Enlight_View_Default;
 use Shopware\SwagCustomSort\Components\Listing;
 use Shopware_Plugins_Frontend_SwagCustomSort_Bootstrap as PluginBootstrap;
 
@@ -57,6 +58,7 @@ class Frontend implements SubscriberInterface
         $categoryId = $view->getAssign('sCategoryContent')['id'];
         $showCustomSort = $categoryComponent->showCustomSortName($categoryId);
         $baseSort = $categoryComponent->getCategoryBaseSort($categoryId);
+        $this->addTemplateDir($view);
         if ($showCustomSort || $baseSort > 0) {
             /** @var Listing $categoryComponent */
             $categoryComponent = $this->bootstrap->get('swagcustomsort.listing_component');
@@ -75,16 +77,26 @@ class Frontend implements SubscriberInterface
     }
 
     /**
-     * @param \Enlight_View_Default $view
-     * @param string                $templatePath
+     * @param Enlight_View_Default $view
      */
-    protected function extendsTemplate($view, $templatePath)
+    protected function addTemplateDir(Enlight_View_Default $view)
     {
         $version = $this->bootstrap->get('shop')->getTemplate()->getVersion();
         if ($version >= 3) {
             $view->addTemplateDir($this->bootstrapPath . 'Views/responsive/');
         } else {
             $view->addTemplateDir($this->bootstrapPath . 'Views/emotion/');
+        }
+    }
+
+    /**
+     * @param Enlight_View_Default $view
+     * @param string                $templatePath
+     */
+    protected function extendsTemplate(Enlight_View_Default $view, $templatePath)
+    {
+        $version = $this->bootstrap->get('shop')->getTemplate()->getVersion();
+        if ($version < 3) {
             $view->extendsTemplate($templatePath);
         }
     }

--- a/Subscriber/Sort.php
+++ b/Subscriber/Sort.php
@@ -131,6 +131,6 @@ class Sort implements SubscriberInterface
      */
     public function onCollectSortingHandlers()
     {
-        return new DragDropHandler($this->sortingComponent);
+        return new DragDropHandler($this->sortingComponent, $this->em);
     }
 }


### PR DESCRIPTION
The concept of filters in Shopware has changed drastically with the release of version 5.3. This plugin used to heavily rely the old filter structure. With this change the plugin will be compatible with the new filter structure of Shopware 5.3 and above. Unfortunately though this will drop support for Shopware 5.2 and below. So maybe a compromise of the status quo and this PR will be sufficient to have the best cross-version compatibility.